### PR TITLE
exemplo de caminho completo e não relativo ao repositorio

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<h2>A revolução do Google está chegando</h2>
 	</hgroup>
 	
-	<img id="icone" src="_imagens\glass-oculos-preto-peq.png">
+	<img id="icone" src="https://raw.githubusercontent.com/Apolinar1o/Apolinar1oDeveloper-s/main/_imagens/glass-oculos-preto-peq.png">
 
 
 <nav id="menu" >


### PR DESCRIPTION
O diferencial é que o github não reconhece o caminho relativo ao repositorio. Tera que especificar o caminho completo, indicando o raw caminho inteiro. tanto nas imagens quanto nos arquivos css e js.
https://raw.githubusercontent.com/Apolinar1o/Apolinar1oDeveloper-s/main/_imagens/glass-oculos-preto-peq.png.

exemplo:
https://github.com/Apolinar1o/Apolinar1oDeveloper-s/blob/main/_css/estilo.css    : Esse caminho indica onde esta o css
no canto subepior tem um botão chamado "raw".. ao clicar sobre ele dara o caminho completo para indicar o link css:

dessa forma:

https://raw.githubusercontent.com/Apolinar1o/Apolinar1oDeveloper-s/main/_css/estilo.css